### PR TITLE
HTTP: Support get Client IP for nginx

### DIFF
--- a/dispatcher/plugin/executable/ecs/ecs.go
+++ b/dispatcher/plugin/executable/ecs/ecs.go
@@ -84,7 +84,7 @@ func newPlugin(bp *handler.BP, args *Args) (p handler.Plugin, err error) {
 		if ip4 := ip.To4(); ip4 == nil {
 			return nil, fmt.Errorf("%s is not a ipv4 address", args.IPv4)
 		} else {
-			ep.ipv4 = newEDNS0Subnet(ip4, args.Mask4, false)
+			ep.ipv4 = NewEDNS0Subnet(ip4, args.Mask4, false)
 		}
 	}
 
@@ -96,7 +96,7 @@ func newPlugin(bp *handler.BP, args *Args) (p handler.Plugin, err error) {
 		if ip6 := ip.To16(); ip6 == nil {
 			return nil, fmt.Errorf("%s is not a ipv6 address", args.IPv6)
 		} else {
-			ep.ipv6 = newEDNS0Subnet(ip6, args.Mask6, true)
+			ep.ipv6 = NewEDNS0Subnet(ip6, args.Mask6, true)
 		}
 	}
 
@@ -120,10 +120,10 @@ func (e ecsPlugin) Exec(_ context.Context, qCtx *handler.Context) (_ error) {
 			return nil
 		}
 		if ip4 := ip.To4(); ip4 != nil { // is ipv4
-			ecs = newEDNS0Subnet(ip4, e.args.Mask4, false)
+			ecs = NewEDNS0Subnet(ip4, e.args.Mask4, false)
 		} else {
 			if ip6 := ip.To16(); ip6 != nil { // is ipv6
-				ecs = newEDNS0Subnet(ip6, e.args.Mask6, true)
+				ecs = NewEDNS0Subnet(ip6, e.args.Mask6, true)
 			} else { // non
 				e.L().Warn("internal err: client ip address is not a valid ip address", qCtx.InfoField(), zap.Stringer("from", qCtx.From()))
 				return nil
@@ -139,7 +139,7 @@ func (e ecsPlugin) Exec(_ context.Context, qCtx *handler.Context) (_ error) {
 	}
 
 	if ecs != nil {
-		setECS(qCtx.Q(), ecs)
+		SetECS(qCtx.Q(), ecs)
 
 		// According to https://tools.ietf.org/html/rfc7871#section-7.2.2
 		// > Because a client that did not use an ECS option might not

--- a/dispatcher/plugin/executable/ecs/ecs_test.go
+++ b/dispatcher/plugin/executable/ecs/ecs_test.go
@@ -54,7 +54,7 @@ ipv6: '2001:dd8:1a::'
 	testFunc := func(presetECS bool) {
 		typ := []uint16{dns.TypeA, dns.TypeAAAA}
 		wantECS := []*dns.EDNS0_SUBNET{ecs.ipv4, ecs.ipv6}
-		otherECS := newEDNS0Subnet(net.IPv4(1, 2, 3, 4), 32, false)
+		otherECS := NewEDNS0Subnet(net.IPv4(1, 2, 3, 4), 32, false)
 
 		for i := 0; i < 2; i++ {
 			m := new(dns.Msg)
@@ -64,7 +64,7 @@ ipv6: '2001:dd8:1a::'
 			}
 
 			if presetECS {
-				setECS(m, otherECS)
+				SetECS(m, otherECS)
 				if getMsgECS(m) != otherECS {
 					t.FailNow()
 				}
@@ -109,9 +109,9 @@ func Test_ecs_auto(t *testing.T) {
 			utils.NewNetAddr("[2001:0db8::]:0", "test"),
 		}
 		wantECS := []*dns.EDNS0_SUBNET{
-			newEDNS0Subnet(net.ParseIP("192.168.0.1").To4(), 24, false),
-			newEDNS0Subnet(net.ParseIP("2001:0db8::").To16(), 32, true)}
-		otherECS := newEDNS0Subnet(net.IPv4(1, 2, 3, 4), 32, false)
+			NewEDNS0Subnet(net.ParseIP("192.168.0.1").To4(), 24, false),
+			NewEDNS0Subnet(net.ParseIP("2001:0db8::").To16(), 32, true)}
+		otherECS := NewEDNS0Subnet(net.IPv4(1, 2, 3, 4), 32, false)
 
 		for i := 0; i < 2; i++ {
 			m := new(dns.Msg)
@@ -121,7 +121,7 @@ func Test_ecs_auto(t *testing.T) {
 			}
 
 			if presetECS {
-				setECS(m, otherECS)
+				SetECS(m, otherECS)
 				if getMsgECS(m) != otherECS {
 					t.FailNow()
 				}
@@ -150,8 +150,8 @@ func Test_ecs_auto(t *testing.T) {
 func Test_remove_ecs(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
-	ecs := newEDNS0Subnet(net.IPv4(1, 2, 3, 4), 32, false)
-	setECS(m, ecs)
+	ecs := NewEDNS0Subnet(net.IPv4(1, 2, 3, 4), 32, false)
+	SetECS(m, ecs)
 
 	p := &noECS{}
 	err := p.Exec(context.Background(), handler.NewContext(m, nil))

--- a/dispatcher/plugin/executable/ecs/utils.go
+++ b/dispatcher/plugin/executable/ecs/utils.go
@@ -52,7 +52,7 @@ func removeECS(m *dns.Msg) (removedECS *dns.EDNS0_SUBNET) {
 	return nil
 }
 
-func setECS(m *dns.Msg, ecs *dns.EDNS0_SUBNET) *dns.Msg {
+func SetECS(m *dns.Msg, ecs *dns.EDNS0_SUBNET) *dns.Msg {
 	opt := m.IsEdns0()
 	if opt == nil { // no opt, we need a new opt
 		o := new(dns.OPT)
@@ -77,7 +77,7 @@ func setECS(m *dns.Msg, ecs *dns.EDNS0_SUBNET) *dns.Msg {
 	return m
 }
 
-func newEDNS0Subnet(ip net.IP, mask uint8, v6 bool) *dns.EDNS0_SUBNET {
+func NewEDNS0Subnet(ip net.IP, mask uint8, v6 bool) *dns.EDNS0_SUBNET {
 	edns0Subnet := new(dns.EDNS0_SUBNET)
 	// edns family: https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml
 	// ipv4 = 1


### PR DESCRIPTION
支持 Nginx 反向代理通过 `X-Forwarded-For` 头获取客户端 IP 用作 ECS

由于原 `dispatcher/plugin/executable/ecs` 内的操作 ECS 的函数都是私有的，放在 Server 引用只能改成全局变量，但是我不确定我这样改是否可行
