### PR TITLE
[BUGFIX]: ipset plugin should not only add the first answer

### DIFF
--- a/plugin/executable/ipset/ipset_linux.go
+++ b/plugin/executable/ipset/ipset_linux.go
@@ -88,7 +88,9 @@ func (p *ipsetPlugin) addIPSet(r *dns.Msg) error {
 			if !ok {
 				return fmt.Errorf("invalid A record with ip: %s", rr.A)
 			}
-			return ipset.AddPrefix(p.nl, p.args.SetName4, netip.PrefixFrom(addr, p.args.Mask4))
+			if err := ipset.AddPrefix(p.nl, p.args.SetName4, netip.PrefixFrom(addr, p.args.Mask4)); err != nil {
+				return err
+			}
 
 		case *dns.AAAA:
 			if len(p.args.SetName6) == 0 {
@@ -98,7 +100,9 @@ func (p *ipsetPlugin) addIPSet(r *dns.Msg) error {
 			if !ok {
 				return fmt.Errorf("invalid AAAA record with ip: %s", rr.AAAA)
 			}
-			return ipset.AddPrefix(p.nl, p.args.SetName6, netip.PrefixFrom(addr, p.args.Mask6))
+			if err := ipset.AddPrefix(p.nl, p.args.SetName6, netip.PrefixFrom(addr, p.args.Mask6)); err != nil {
+				return err
+			}
 		default:
 			continue
 		}


### PR DESCRIPTION
I find a bug that if the upstream returned more than one answer, the ipset plugin only added the first to the ipset. So I checked the code and find what happened, and changed some code and fixed this bug.
