### PR TITLE
Fix: query_matcher cannot load ECS ip

### DIFF
--- a/plugin/matcher/query_matcher/query_matcher.go
+++ b/plugin/matcher/query_matcher/query_matcher.go
@@ -21,6 +21,7 @@ package querymatcher
 
 import (
 	"context"
+
 	"github.com/IrineSistiana/mosdns/v4/coremain"
 	"github.com/IrineSistiana/mosdns/v4/pkg/executable_seq"
 	"github.com/IrineSistiana/mosdns/v4/pkg/matcher/domain"
@@ -97,7 +98,7 @@ func newQueryMatcher(bp *coremain.BP, args *Args) (m *queryMatcher, err error) {
 		bp.L().Info("client ip matcher loaded", zap.Int("length", l.Len()))
 	}
 	if len(args.ECS) > 0 {
-		l, err := netlist.BatchLoadProvider(args.ClientIP, bp.M().GetDataManager())
+		l, err := netlist.BatchLoadProvider(args.ECS, bp.M().GetDataManager())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
无 ```client_ip:```
```
2022-09-13T09:24:24.293Z	info	coremain/mosdns.go:123	loading plugin	{"tag": "query_with_local_ecs", "type": "query_matcher"}
2022-09-13T09:24:24.293Z	info	query_matcher/query_matcher.go:105	ecs ip matcher loaded	{"length": 0}
```
有 ```client_ip:```
```
2022-09-13T09:26:02.590Z	info	coremain/mosdns.go:123	loading plugin	{"tag": "query_with_local_ecs", "type": "query_matcher"}
2022-09-13T09:26:02.590Z	info	query_matcher/query_matcher.go:97	client ip matcher loaded	{"length": 1}
2022-09-13T09:26:02.590Z	info	query_matcher/query_matcher.go:105	ecs ip matcher loaded	{"length": 1}
```