### PR TITLE
upstream: add bootstrap server

### DIFF
--- a/pkg/upstream/bootstrap/bootstrap.go
+++ b/pkg/upstream/bootstrap/bootstrap.go
@@ -22,7 +22,6 @@ package bootstrap
 import (
 	"context"
 	"net"
-	"strconv"
 	"strings"
 )
 
@@ -52,16 +51,4 @@ func NewPlainBootstrap(s string) *net.Resolver {
 			return d.DialContext(ctx, network, s)
 		},
 	}
-}
-
-func getDialAddrWithPort(host, dialAddr string, defaultPort int) string {
-	addr := host
-	if len(dialAddr) > 0 {
-		addr = dialAddr
-	}
-	_, _, err := net.SplitHostPort(addr)
-	if err != nil { // no port, add it.
-		return net.JoinHostPort(strings.Trim(addr, "[]"), strconv.Itoa(defaultPort))
-	}
-	return addr
 }

--- a/pkg/upstream/utils.go
+++ b/pkg/upstream/utils.go
@@ -26,15 +26,14 @@ import (
 	"net"
 )
 
-func dialTCP(ctx context.Context, addr, socks5 string, mark int) (net.Conn, error) {
+func dialTCP(ctx context.Context, addr, socks5 string, dialer *net.Dialer) (net.Conn, error) {
 	if len(socks5) > 0 {
-		socks5Dialer, err := proxy.SOCKS5("tcp", socks5, nil, nil)
+		socks5Dialer, err := proxy.SOCKS5("tcp", socks5, nil, dialer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to init socks5 dialer: %w", err)
 		}
 		return socks5Dialer.(proxy.ContextDialer).DialContext(ctx, "tcp", addr)
 	}
 
-	d := net.Dialer{Control: getSetMarkFunc(mark)}
-	return d.DialContext(ctx, "tcp", addr)
+	return dialer.DialContext(ctx, "tcp", addr)
 }

--- a/plugin/executable/fast_forward/fast_forward.go
+++ b/plugin/executable/fast_forward/fast_forward.go
@@ -66,11 +66,12 @@ type UpstreamConfig struct {
 	Socks5   string `yaml:"socks5"`
 	SoMark   int    `yaml:"so_mark"`
 
-	IdleTimeout        int  `yaml:"idle_timeout"`
-	MaxConns           int  `yaml:"max_conns"`
-	EnablePipeline     bool `yaml:"enable_pipeline"`
-	EnableHTTP3        bool `yaml:"enable_http3"`
-	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
+	IdleTimeout        int    `yaml:"idle_timeout"`
+	MaxConns           int    `yaml:"max_conns"`
+	EnablePipeline     bool   `yaml:"enable_pipeline"`
+	EnableHTTP3        bool   `yaml:"enable_http3"`
+	Bootstrap          string `yaml:"bootstrap"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
 }
 
 func Init(bp *coremain.BP, args interface{}) (p coremain.Plugin, err error) {
@@ -121,6 +122,7 @@ func newFastForward(bp *coremain.BP, args *Args) (*fastForward, error) {
 			MaxConns:       c.MaxConns,
 			EnablePipeline: c.EnablePipeline,
 			EnableHTTP3:    c.EnableHTTP3,
+			Bootstrap:      c.Bootstrap,
 			TLSConfig: &tls.Config{
 				InsecureSkipVerify: c.InsecureSkipVerify,
 				RootCAs:            rootCAs,


### PR DESCRIPTION
fast_forward 新增 bootstrap 支持。

注意事项: 

- http3 不支持。
- 基于 net.Resolver , 只有部分系统支持。还取决于编译时的 go 版本。https://pkg.go.dev/net 文档写的不清楚，1.19 版本能确定 Unix 系统支持。windows 似乎支持？macos 和 plan9 不支持。
- 没有缓存。每次 dial 连接都会请求一次 DNS。会有一点可观的延时影响。官方的意思是 net.Resolver 希望服务器是本地的而且有缓存。
