### PR TITLE
增加 Maxmind DB 匹配器，用于匹配 response ip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is a Go module: `github.com/IrineSistiana/mosdns/v5`.
+
+- `main.go` wires the CLI and imports enabled plugins.
+- `coremain/` contains config loading, service startup, and plugin lifecycle.
+- `pkg/` holds reusable libraries such as DNS utilities, server handlers, upstream transports, cache, matchers, and zone-file parsing.
+- `plugin/` contains configurable runtime extensions, grouped by role: `data_provider/`, `matcher/`, `executable/`, `server/`, and `mark/`.
+- `tools/` adds CLI helpers such as config generation/conversion.
+- `scripts/` contains packaging and platform helper scripts.
+- Tests live beside implementation files as `*_test.go`.
+
+Avoid committing large local data files such as `geoip.dat`, `geosite.dat`, generated certs, or local-only config experiments unless explicitly requested.
+
+## Build, Test, and Development Commands
+
+- `go test ./...` runs the full test suite.
+- `go test ./plugin/...` runs plugin-focused tests.
+- `go test ./pkg/upstream/...` is useful after transport or TFO changes.
+- `go run . start -c config.yaml -d "$(pwd)"` starts mosdns with a local config.
+- `go run . config gen config.yaml` generates a template config.
+- `go build ./...` verifies all packages compile.
+
+Use `gofmt -w <files>` before committing Go changes.
+
+## Coding Style & Naming Conventions
+
+Follow standard Go formatting and idioms. Package names are lower-case and directory-oriented. Plugin packages should expose a clear `PluginType` constant and register themselves in `init()`. If a plugin must be available in normal builds, add its blank import in `plugin/enabled_plugins.go`.
+
+Keep configuration keys stable and YAML tags explicit. Prefer small, focused helpers over broad refactors.
+
+## Testing Guidelines
+
+Use Go’s built-in `testing` package; existing tests may also use `testify`. Put tests next to the code under test and name them `TestXxx`. For plugins, cover both provider loading and matcher/executable behavior. For network-facing changes, include local loopback tests when possible and document any required kernel/sysctl assumptions.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use short imperative messages, for example `add tcp fast open support` or `enable geosite matcher plugin`. Keep commits scoped to one logical change.
+
+Pull requests should include a short problem statement, the implementation summary, tests run, and any config or compatibility notes. Link issues when applicable, and include logs or command output for networking behavior changes.
+
+## Security & Configuration Tips
+
+Do not commit secrets, private upstream URLs, generated private keys, or local DNS datasets. Keep sample configs deterministic and prefer loopback addresses for tests and examples.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,116 @@
 下载预编译文件、更新日志，详见: [release](https://github.com/IrineSistiana/mosdns/releases)
 
 docker 镜像: [docker hub](https://hub.docker.com/r/irinesistiana/mosdns)
+
+
+## 补充配置示例
+
+### mmdb / geoip / geosite
+
+`mmdb`、`geoip`、`geosite` 都是数据提供插件，需要先配置数据文件，再在 `sequence` 中通过对应 matcher 引用。
+
+- `mmdb` 使用 MaxMind mmdb 数据库，配合 `resp_ip_mmdb` 按响应 IP 的国家/地区 ISO code 匹配。
+- `geoip` 使用 v2ray `geoip.dat`，配合 `resp_ip_geoip` 按响应 IP 所属列表匹配。
+- `geosite` 使用 v2ray `geosite.dat`，配合 `qname_geosite` 按请求域名所属列表匹配，支持 geosite attr，例如 `cn@cn`。
+
+示例：
+
+```yaml
+plugins:
+  - tag: mmdb
+    type: mmdb
+    args:
+      file: /etc/mosdns/GeoLite2-Country.mmdb
+
+  - tag: geoip
+    type: geoip
+    args:
+      file: /etc/mosdns/geoip.dat
+
+  - tag: geosite
+    type: geosite
+    args:
+      file: /etc/mosdns/geosite.dat
+
+  - tag: forward_local
+    type: forward
+    args:
+      upstreams:
+        - addr: 223.5.5.5
+
+  - tag: forward_remote
+    type: forward
+    args:
+      upstreams:
+        - addr: tls://8.8.8.8
+
+  - tag: main_sequence
+    type: sequence
+    args:
+      - matches:
+          - qname_geosite $geosite cn
+        exec: forward_local
+
+      - matches:
+          - qname_geosite $geosite cn@cn
+        exec: forward_local
+
+      - matches:
+          - resp_ip_geoip $geoip cn
+        exec: forward_local
+
+      - matches:
+          - resp_ip_mmdb $mmdb CN
+        exec: forward_local
+
+      - exec: forward_remote
+```
+
+### TCP Fast Open
+
+TCP Fast Open 通过 `enable_tfo: true` 开启。该选项只影响 TCP 类 socket；在不支持 TFO 的系统上不会生效。Linux 环境还需要系统内核和 `net.ipv4.tcp_fastopen` 允许对应方向的 TFO。
+
+Server 示例：
+
+```yaml
+plugins:
+  - tag: tcp_server
+    type: tcp_server
+    args:
+      entry: main_sequence
+      listen: 0.0.0.0:53
+      enable_tfo: true
+
+  - tag: http_server
+    type: http_server
+    args:
+      entries:
+        - path: /dns-query
+          exec: main_sequence
+      listen: 0.0.0.0:443
+      cert: /etc/mosdns/server.crt
+      key: /etc/mosdns/server.key
+      enable_tfo: true
+```
+
+Upstream 示例：
+
+```yaml
+plugins:
+  - tag: forward_tfo
+    type: forward
+    args:
+      enable_tfo: true
+      upstreams:
+        - addr: tcp://8.8.8.8
+        - addr: tls://1.1.1.1
+
+  - tag: forward_tfo_mixed
+    type: forward
+    args:
+      upstreams:
+        - addr: tcp://8.8.4.4
+          enable_tfo: true
+        - addr: https://dns.google/dns-query
+          enable_tfo: true
+```

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nadoo/ipset v0.5.0
+	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/quic-go/quic-go v0.59.0
 	github.com/spf13/cobra v1.10.2
@@ -40,6 +41,7 @@ require (
 	github.com/mdlayher/netlink v1.8.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,10 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/oschwald/geoip2-golang v1.13.0 h1:Q44/Ldc703pasJeP5V9+aFSZFmBN7DKHbNsSFzQATJI=
+github.com/oschwald/geoip2-golang v1.13.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
+github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
+github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/mlog/logger.go
+++ b/mlog/logger.go
@@ -21,9 +21,11 @@ package mlog
 
 import (
 	"fmt"
+	"os"
+	"time"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"os"
 )
 
 type LogConfig struct {
@@ -64,10 +66,18 @@ func NewLogger(lc LogConfig) (*zap.Logger, error) {
 		out = stderr
 	}
 
-	if lc.Production {
-		return zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), out, lvl)), nil
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	encoderConfig.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		enc.AppendString(t.Format("2006-01-02 15:04:05"))
 	}
-	return zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()), out, lvl)), nil
+
+	core := zapcore.NewCore(
+		zapcore.NewConsoleEncoder(encoderConfig),
+		out,
+		lvl,
+	)
+
+	return zap.New(core), nil
 }
 
 // L is a global logger.

--- a/pkg/server/http_handler.go
+++ b/pkg/server/http_handler.go
@@ -91,6 +91,7 @@ func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		h.warnErr(req, "invalid request", err)
 		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Bad Request"))
 		return
 	}
 

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -87,6 +87,9 @@ type Opt struct {
 	// BindToDevice sets the socket SO_BINDTODEVICE option in unix system.
 	BindToDevice string
 
+	// EnableTCPFastOpen enables TCP Fast Open for TCP based upstreams in unix system.
+	EnableTCPFastOpen bool
+
 	// IdleTimeout specifies the idle timeout for long-connections.
 	// Default: TCP, DoT: 10s , DoH, DoH3, Quic: 30s.
 	IdleTimeout time.Duration
@@ -163,6 +166,7 @@ func NewUpstream(addr string, opt Opt) (_ Upstream, err error) {
 		Control: getSocketControlFunc(socketOpts{
 			so_mark:        opt.SoMark,
 			bind_to_device: opt.BindToDevice,
+			tcp_fast_open:  opt.EnableTCPFastOpen,
 		}),
 	}
 

--- a/pkg/upstream/utils.go
+++ b/pkg/upstream/utils.go
@@ -29,6 +29,7 @@ import (
 type socketOpts struct {
 	so_mark        int
 	bind_to_device string
+	tcp_fast_open  bool
 }
 
 func parseDialAddr(urlHost, dialAddr string, defaultPort uint16) (string, uint16, error) {

--- a/pkg/upstream/utils_unix.go
+++ b/pkg/upstream/utils_unix.go
@@ -29,9 +29,17 @@ import (
 )
 
 func getSocketControlFunc(opts socketOpts) func(string, string, syscall.RawConn) error {
-	return func(_, _ string, c syscall.RawConn) error {
+	return func(network, _ string, c syscall.RawConn) error {
 		var sysCallErr error
 		if err := c.Control(func(fd uintptr) {
+			if opts.tcp_fast_open && isTCPNetwork(network) {
+				sysCallErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_FASTOPEN_CONNECT, 1)
+				if sysCallErr != nil {
+					sysCallErr = os.NewSyscallError("failed to set TCP_FASTOPEN_CONNECT", sysCallErr)
+					return
+				}
+			}
+
 			// SO_MARK
 			if opts.so_mark > 0 {
 				sysCallErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_MARK, opts.so_mark)
@@ -54,5 +62,14 @@ func getSocketControlFunc(opts socketOpts) func(string, string, syscall.RawConn)
 			return err
 		}
 		return sysCallErr
+	}
+}
+
+func isTCPNetwork(network string) bool {
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		return true
+	default:
+		return false
 	}
 }

--- a/plugin/data_provider/geoip/geoip.go
+++ b/plugin/data_provider/geoip/geoip.go
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2020-2022, IrineSistiana
+ *
+ * This file is part of mosdns.
+ *
+ * mosdns is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * mosdns is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package geoip
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"strings"
+
+	"github.com/IrineSistiana/mosdns/v5/coremain"
+	"github.com/IrineSistiana/mosdns/v5/pkg/matcher/netlist"
+	"github.com/IrineSistiana/mosdns/v5/plugin/data_provider"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+const PluginType = "geoip"
+
+func init() {
+	coremain.RegNewPluginFunc(PluginType, Init, func() any { return new(Args) })
+}
+
+func Init(bp *coremain.BP, args any) (any, error) {
+	return NewGeoIP(bp, args.(*Args))
+}
+
+type Args struct {
+	File string `yaml:"file"`
+}
+
+var _ data_provider.GeoIPMatcherProvider = (*GeoIP)(nil)
+
+type GeoIP struct {
+	matchers map[string]netlist.Matcher
+}
+
+func (g *GeoIP) GetGeoIPMatcher(code string) (netlist.Matcher, bool) {
+	m, ok := g.matchers[strings.ToLower(code)]
+	return m, ok
+}
+
+func NewGeoIP(bp *coremain.BP, args *Args) (*GeoIP, error) {
+	matchers, err := LoadGeoIP(args.File)
+	if err != nil {
+		return nil, err
+	}
+	return &GeoIP{matchers: matchers}, nil
+}
+
+type notMatcher struct {
+	m netlist.Matcher
+}
+
+func (m notMatcher) Match(addr netip.Addr) bool {
+	return !m.m.Match(addr)
+}
+
+func LoadGeoIP(file string) (map[string]netlist.Matcher, error) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return DecodeGeoIPList(b)
+}
+
+func DecodeGeoIPList(b []byte) (map[string]netlist.Matcher, error) {
+	matchers := make(map[string]netlist.Matcher)
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		if num != 1 || typ != protowire.BytesType {
+			return nil
+		}
+		code, matcher, err := decodeGeoIP(value)
+		if err != nil {
+			return err
+		}
+		if len(code) != 0 {
+			matchers[strings.ToLower(code)] = matcher
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return matchers, nil
+}
+
+func decodeGeoIP(b []byte) (string, netlist.Matcher, error) {
+	var code string
+	var inverse bool
+	l := netlist.NewList()
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		switch num {
+		case 1:
+			if typ == protowire.BytesType {
+				code = string(value)
+			}
+		case 2:
+			if typ != protowire.BytesType {
+				return nil
+			}
+			prefix, err := decodeCIDR(value)
+			if err != nil {
+				return err
+			}
+			l.Append(prefix)
+		case 3:
+			if typ != protowire.VarintType {
+				return nil
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+			inverse = v != 0
+		case 5:
+			if typ == protowire.BytesType && len(code) == 0 {
+				code = string(value)
+			}
+		}
+		return nil
+	}); err != nil {
+		return "", nil, err
+	}
+
+	l.Sort()
+	if inverse {
+		return code, notMatcher{m: l}, nil
+	}
+	return code, l, nil
+}
+
+func decodeCIDR(b []byte) (netip.Prefix, error) {
+	var ip []byte
+	var bits int
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		switch num {
+		case 1:
+			if typ == protowire.BytesType {
+				ip = value
+			}
+		case 2:
+			if typ != protowire.VarintType {
+				return nil
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+			bits = int(v)
+		}
+		return nil
+	}); err != nil {
+		return netip.Prefix{}, err
+	}
+
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return netip.Prefix{}, fmt.Errorf("invalid CIDR IP %x", ip)
+	}
+	prefix := netip.PrefixFrom(addr, bits)
+	if !prefix.IsValid() {
+		return netip.Prefix{}, fmt.Errorf("invalid CIDR prefix %s/%d", addr, bits)
+	}
+	return prefix.Masked(), nil
+}
+
+func forEachField(b []byte, f func(num protowire.Number, typ protowire.Type, value []byte) error) error {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		b = b[n:]
+
+		vn := protowire.ConsumeFieldValue(num, typ, b)
+		if vn < 0 {
+			return protowire.ParseError(vn)
+		}
+		value := b[:vn]
+		if typ == protowire.BytesType {
+			var n int
+			value, n = protowire.ConsumeBytes(value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+		}
+		if err := f(num, typ, value); err != nil {
+			return err
+		}
+		b = b[vn:]
+	}
+	return nil
+}

--- a/plugin/data_provider/geoip/geoip_test.go
+++ b/plugin/data_provider/geoip/geoip_test.go
@@ -1,0 +1,90 @@
+package geoip
+
+import (
+	"net/netip"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func TestDecodeGeoIPList(t *testing.T) {
+	b := appendMessage(nil, 1, geoIP("CN", false,
+		cidr(netip.MustParseAddr("1.0.0.0"), 24),
+		cidr(netip.MustParseAddr("2001:db8::"), 32),
+	))
+	b = appendMessage(b, 1, geoIP("TEST", true,
+		cidr(netip.MustParseAddr("10.0.0.0"), 8),
+	))
+
+	matchers, err := DecodeGeoIPList(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cn := matchers["cn"]
+	if cn == nil {
+		t.Fatal("missing cn matcher")
+	}
+	if !cn.Match(netip.MustParseAddr("1.0.0.1")) {
+		t.Fatal("cn matcher did not match IPv4 prefix")
+	}
+	if !cn.Match(netip.MustParseAddr("2001:db8::1")) {
+		t.Fatal("cn matcher did not match IPv6 prefix")
+	}
+	if cn.Match(netip.MustParseAddr("2.0.0.1")) {
+		t.Fatal("cn matcher unexpectedly matched different IPv4 prefix")
+	}
+
+	test := matchers["test"]
+	if test == nil {
+		t.Fatal("missing test matcher")
+	}
+	if test.Match(netip.MustParseAddr("10.0.0.1")) {
+		t.Fatal("inverse matcher unexpectedly matched excluded prefix")
+	}
+	if !test.Match(netip.MustParseAddr("11.0.0.1")) {
+		t.Fatal("inverse matcher did not match non-excluded prefix")
+	}
+}
+
+func geoIP(code string, inverse bool, cidrs ...[]byte) []byte {
+	var b []byte
+	b = appendString(b, 1, code)
+	for _, cidr := range cidrs {
+		b = appendMessage(b, 2, cidr)
+	}
+	if inverse {
+		b = appendVarint(b, 3, 1)
+	}
+	return b
+}
+
+func cidr(addr netip.Addr, bits uint64) []byte {
+	var b []byte
+	if addr.Is4() {
+		a := addr.As4()
+		b = appendBytes(b, 1, a[:])
+	} else {
+		a := addr.As16()
+		b = appendBytes(b, 1, a[:])
+	}
+	return appendVarint(b, 2, bits)
+}
+
+func appendString(b []byte, num protowire.Number, s string) []byte {
+	return appendBytes(b, num, []byte(s))
+}
+
+func appendMessage(b []byte, num protowire.Number, msg []byte) []byte {
+	return appendBytes(b, num, msg)
+}
+
+func appendBytes(b []byte, num protowire.Number, value []byte) []byte {
+	b = protowire.AppendTag(b, num, protowire.BytesType)
+	return protowire.AppendBytes(b, value)
+}
+
+func appendVarint(b []byte, num protowire.Number, value uint64) []byte {
+	b = protowire.AppendTag(b, num, protowire.VarintType)
+	return protowire.AppendVarint(b, value)
+}

--- a/plugin/data_provider/geosite/geosite.go
+++ b/plugin/data_provider/geosite/geosite.go
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2020-2022, IrineSistiana
+ *
+ * This file is part of mosdns.
+ *
+ * mosdns is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * mosdns is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package geosite
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/IrineSistiana/mosdns/v5/coremain"
+	"github.com/IrineSistiana/mosdns/v5/pkg/matcher/domain"
+	"github.com/IrineSistiana/mosdns/v5/plugin/data_provider"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+const PluginType = "geosite"
+
+const (
+	geositeDomainPlain  = 0
+	geositeDomainRegex  = 1
+	geositeDomainDomain = 2
+	geositeDomainFull   = 3
+)
+
+func init() {
+	coremain.RegNewPluginFunc(PluginType, Init, func() any { return new(Args) })
+}
+
+func Init(bp *coremain.BP, args any) (any, error) {
+	return NewGeosite(bp, args.(*Args))
+}
+
+type Args struct {
+	File string `yaml:"file"`
+}
+
+var _ data_provider.GeositeMatcherProvider = (*Geosite)(nil)
+
+type Geosite struct {
+	mu       sync.Mutex
+	sites    map[string][]geositeDomain
+	matchers map[string]domain.Matcher[struct{}]
+}
+
+func (g *Geosite) GetGeositeMatcher(code string) (domain.Matcher[struct{}], bool) {
+	name, attrs := parseCode(code)
+	if len(name) == 0 {
+		return nil, false
+	}
+
+	cacheKey := name
+	if len(attrs) > 0 {
+		cacheKey += "@" + strings.Join(attrs, "@")
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if m, ok := g.matchers[cacheKey]; ok {
+		return m, true
+	}
+
+	domains, ok := g.sites[name]
+	if !ok {
+		return nil, false
+	}
+	m, err := buildMatcher(domains, attrs)
+	if err != nil {
+		return nil, false
+	}
+	g.matchers[cacheKey] = m
+	return m, true
+}
+
+func NewGeosite(bp *coremain.BP, args *Args) (*Geosite, error) {
+	sites, err := LoadGeosite(args.File)
+	if err != nil {
+		return nil, err
+	}
+	return &Geosite{
+		sites:    sites,
+		matchers: make(map[string]domain.Matcher[struct{}]),
+	}, nil
+}
+
+type geositeDomain struct {
+	typ   uint64
+	value string
+	attrs map[string]struct{}
+}
+
+func LoadGeosite(file string) (map[string][]geositeDomain, error) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return DecodeGeositeList(b)
+}
+
+func DecodeGeositeList(b []byte) (map[string][]geositeDomain, error) {
+	sites := make(map[string][]geositeDomain)
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		if num != 1 || typ != protowire.BytesType {
+			return nil
+		}
+		code, domains, err := decodeGeosite(value)
+		if err != nil {
+			return err
+		}
+		if len(code) != 0 {
+			sites[strings.ToLower(code)] = domains
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return sites, nil
+}
+
+func decodeGeosite(b []byte) (string, []geositeDomain, error) {
+	var code string
+	var domains []geositeDomain
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		switch num {
+		case 1:
+			if typ == protowire.BytesType {
+				code = string(value)
+			}
+		case 2:
+			if typ != protowire.BytesType {
+				return nil
+			}
+			d, err := decodeGeositeDomain(value)
+			if err != nil {
+				return err
+			}
+			if len(d.value) != 0 {
+				domains = append(domains, d)
+			}
+		}
+		return nil
+	}); err != nil {
+		return "", nil, err
+	}
+	return code, domains, nil
+}
+
+func decodeGeositeDomain(b []byte) (geositeDomain, error) {
+	d := geositeDomain{typ: geositeDomainPlain}
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		switch num {
+		case 1:
+			if typ != protowire.VarintType {
+				return nil
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+			d.typ = v
+		case 2:
+			if typ == protowire.BytesType {
+				d.value = string(value)
+			}
+		case 3:
+			if typ != protowire.BytesType {
+				return nil
+			}
+			key, err := decodeGeositeAttribute(value)
+			if err != nil {
+				return err
+			}
+			if len(key) != 0 {
+				if d.attrs == nil {
+					d.attrs = make(map[string]struct{})
+				}
+				d.attrs[strings.ToLower(key)] = struct{}{}
+			}
+		}
+		return nil
+	}); err != nil {
+		return geositeDomain{}, err
+	}
+	return d, nil
+}
+
+func decodeGeositeAttribute(b []byte) (string, error) {
+	var key string
+	if err := forEachField(b, func(num protowire.Number, typ protowire.Type, value []byte) error {
+		if num == 1 && typ == protowire.BytesType {
+			key = string(value)
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func parseCode(code string) (string, []string) {
+	parts := strings.Split(strings.ToLower(code), "@")
+	name := strings.TrimSpace(parts[0])
+	var attrs []string
+	for _, attr := range parts[1:] {
+		attr = strings.TrimSpace(attr)
+		if len(attr) != 0 {
+			attrs = append(attrs, attr)
+		}
+	}
+	return name, attrs
+}
+
+func buildMatcher(domains []geositeDomain, attrs []string) (domain.Matcher[struct{}], error) {
+	m := domain.NewDomainMixMatcher()
+	for _, d := range domains {
+		if !matchAttrs(d, attrs) {
+			continue
+		}
+		if err := addGeositeDomain(m, d); err != nil {
+			return nil, err
+		}
+	}
+	return m, nil
+}
+
+func matchAttrs(d geositeDomain, attrs []string) bool {
+	for _, attr := range attrs {
+		if _, ok := d.attrs[attr]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func addGeositeDomain(m *domain.MixMatcher[struct{}], d geositeDomain) error {
+	var matcher string
+	switch d.typ {
+	case geositeDomainPlain:
+		matcher = domain.MatcherKeyword
+	case geositeDomainRegex:
+		matcher = domain.MatcherRegexp
+	case geositeDomainDomain:
+		matcher = domain.MatcherDomain
+	case geositeDomainFull:
+		matcher = domain.MatcherFull
+	default:
+		return fmt.Errorf("unsupported geosite domain type %d", d.typ)
+	}
+	return m.GetSubMatcher(matcher).Add(d.value, struct{}{})
+}
+
+func forEachField(b []byte, f func(num protowire.Number, typ protowire.Type, value []byte) error) error {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		b = b[n:]
+
+		vn := protowire.ConsumeFieldValue(num, typ, b)
+		if vn < 0 {
+			return protowire.ParseError(vn)
+		}
+		value := b[:vn]
+		if typ == protowire.BytesType {
+			var n int
+			value, n = protowire.ConsumeBytes(value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+		}
+		if err := f(num, typ, value); err != nil {
+			return err
+		}
+		b = b[vn:]
+	}
+	return nil
+}

--- a/plugin/data_provider/geosite/geosite_test.go
+++ b/plugin/data_provider/geosite/geosite_test.go
@@ -1,0 +1,123 @@
+package geosite
+
+import (
+	"testing"
+
+	"github.com/IrineSistiana/mosdns/v5/pkg/matcher/domain"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func TestDecodeGeositeList(t *testing.T) {
+	b := appendMessage(nil, 1, geoSite("CN",
+		geositeDomainMsg(geositeDomainDomain, "example.com"),
+		geositeDomainMsg(geositeDomainFull, "full.example"),
+		geositeDomainMsg(geositeDomainPlain, "keyword"),
+		geositeDomainMsg(geositeDomainRegex, `^regexp\.example$`),
+	))
+
+	sites, err := DecodeGeositeList(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := buildMatcher(sites["cn"], nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		domain string
+		want   bool
+	}{
+		{"example.com", true},
+		{"www.example.com.", true},
+		{"full.example", true},
+		{"www.full.example", false},
+		{"has-keyword.example", true},
+		{"regexp.example", true},
+		{"regexp.example.org", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.domain, func(t *testing.T) {
+			_, got := m.Match(tt.domain)
+			if got != tt.want {
+				t.Fatalf("Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGeositeMatcherWithAttrs(t *testing.T) {
+	g := &Geosite{
+		sites: map[string][]geositeDomain{
+			"cn": {
+				{typ: geositeDomainDomain, value: "cn.example", attrs: map[string]struct{}{"cn": {}}},
+				{typ: geositeDomainDomain, value: "ads.example", attrs: map[string]struct{}{"ads": {}}},
+				{typ: geositeDomainDomain, value: "plain.example"},
+			},
+		},
+		matchers: make(map[string]domain.Matcher[struct{}]),
+	}
+
+	m, ok := g.GetGeositeMatcher("cn@cn")
+	if !ok {
+		t.Fatal("missing cn@cn matcher")
+	}
+	if _, ok := m.Match("www.cn.example"); !ok {
+		t.Fatal("cn@cn matcher did not include cn attr domain")
+	}
+	if _, ok := m.Match("www.ads.example"); ok {
+		t.Fatal("cn@cn matcher included ads attr domain")
+	}
+	if _, ok := m.Match("www.plain.example"); ok {
+		t.Fatal("cn@cn matcher included domain without attr")
+	}
+
+	m, ok = g.GetGeositeMatcher("cn")
+	if !ok {
+		t.Fatal("missing cn matcher")
+	}
+	if _, ok := m.Match("www.ads.example"); !ok {
+		t.Fatal("cn matcher did not include unfiltered ads attr domain")
+	}
+}
+
+func geoSite(code string, domains ...[]byte) []byte {
+	var b []byte
+	b = appendString(b, 1, code)
+	for _, domain := range domains {
+		b = appendMessage(b, 2, domain)
+	}
+	return b
+}
+
+func geositeDomainMsg(typ uint64, value string, attrs ...string) []byte {
+	var b []byte
+	b = appendVarint(b, 1, typ)
+	b = appendString(b, 2, value)
+	for _, attr := range attrs {
+		b = appendMessage(b, 3, geositeAttr(attr))
+	}
+	return b
+}
+
+func geositeAttr(key string) []byte {
+	return appendString(nil, 1, key)
+}
+
+func appendString(b []byte, num protowire.Number, s string) []byte {
+	return appendBytes(b, num, []byte(s))
+}
+
+func appendMessage(b []byte, num protowire.Number, msg []byte) []byte {
+	return appendBytes(b, num, msg)
+}
+
+func appendBytes(b []byte, num protowire.Number, value []byte) []byte {
+	b = protowire.AppendTag(b, num, protowire.BytesType)
+	return protowire.AppendBytes(b, value)
+}
+
+func appendVarint(b []byte, num protowire.Number, value uint64) []byte {
+	b = protowire.AppendTag(b, num, protowire.VarintType)
+	return protowire.AppendVarint(b, value)
+}

--- a/plugin/data_provider/iface.go
+++ b/plugin/data_provider/iface.go
@@ -29,6 +29,10 @@ type DomainMatcherProvider interface {
 	GetDomainMatcher() domain.Matcher[struct{}]
 }
 
+type GeositeMatcherProvider interface {
+	GetGeositeMatcher(code string) (domain.Matcher[struct{}], bool)
+}
+
 type IPMatcherProvider interface {
 	GetIPMatcher() netlist.Matcher
 }

--- a/plugin/data_provider/iface.go
+++ b/plugin/data_provider/iface.go
@@ -33,6 +33,10 @@ type IPMatcherProvider interface {
 	GetIPMatcher() netlist.Matcher
 }
 
+type GeoIPMatcherProvider interface {
+	GetGeoIPMatcher(code string) (netlist.Matcher, bool)
+}
+
 type MmdbMatcherProvider interface {
 	GetMmdbMatcher() *geoip2.Reader
 }

--- a/plugin/enabled_plugins.go
+++ b/plugin/enabled_plugins.go
@@ -24,6 +24,7 @@ import (
 	// data provider
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/domain_set"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/ip_set"
+	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/mmdb"
 
 	// matcher
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/client_ip"
@@ -38,6 +39,7 @@ import (
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/random"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/rcode"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/resp_ip"
+	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/resp_ip_mmdb"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/string_exp"
 
 	// executable

--- a/plugin/enabled_plugins.go
+++ b/plugin/enabled_plugins.go
@@ -23,6 +23,7 @@ package plugin
 import (
 	// data provider
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/domain_set"
+	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/geoip"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/ip_set"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/mmdb"
 
@@ -39,6 +40,7 @@ import (
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/random"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/rcode"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/resp_ip"
+	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/resp_ip_geoip"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/resp_ip_mmdb"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/string_exp"
 

--- a/plugin/enabled_plugins.go
+++ b/plugin/enabled_plugins.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/ptr_ip"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/qclass"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/qname"
+	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/qname_geosite"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/qtype"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/random"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/matcher/rcode"

--- a/plugin/enabled_plugins.go
+++ b/plugin/enabled_plugins.go
@@ -24,6 +24,7 @@ import (
 	// data provider
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/domain_set"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/geoip"
+	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/geosite"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/ip_set"
 	_ "github.com/IrineSistiana/mosdns/v5/plugin/data_provider/mmdb"
 

--- a/plugin/executable/black_hole/black_hole.go
+++ b/plugin/executable/black_hole/black_hole.go
@@ -27,6 +27,8 @@ import (
 	"github.com/miekg/dns"
 	"net/netip"
 	"strings"
+	"math/rand"
+	"sync"
 )
 
 const PluginType = "black_hole"
@@ -40,6 +42,7 @@ var _ sequence.Executable = (*BlackHole)(nil)
 type BlackHole struct {
 	ipv4 []netip.Addr
 	ipv6 []netip.Addr
+	shuffleMutex sync.Mutex
 }
 
 // QuickSetup format: [ipv4|ipv6] ...
@@ -65,9 +68,21 @@ func NewBlackHole(ips []string) (*BlackHole, error) {
 	return b, nil
 }
 
+func (b *BlackHole) shuffleIPs() {
+	b.shuffleMutex.Lock()
+	defer b.shuffleMutex.Unlock()
+	rand.Shuffle(len(b.ipv4), func(i, j int) {
+		b.ipv4[i], b.ipv4[j] = b.ipv4[j], b.ipv4[i]
+	})
+	rand.Shuffle(len(b.ipv6), func(i, j int) {
+		b.ipv6[i], b.ipv6[j] = b.ipv6[j], b.ipv6[i]
+	})
+}
+
 // Exec implements sequence.Executable. It set a response with given ips if
 // query has corresponding qtypes.
 func (b *BlackHole) Exec(_ context.Context, qCtx *query_context.Context) error {
+	b.shuffleIPs()
 	if r := b.Response(qCtx.Q()); r != nil {
 		qCtx.SetResponse(r)
 	}

--- a/plugin/executable/forward/forward.go
+++ b/plugin/executable/forward/forward.go
@@ -56,11 +56,12 @@ type Args struct {
 	Concurrent int              `yaml:"concurrent"`
 
 	// Global options.
-	Socks5       string `yaml:"socks5"`
-	SoMark       int    `yaml:"so_mark"`
-	BindToDevice string `yaml:"bind_to_device"`
-	Bootstrap    string `yaml:"bootstrap"`
-	BootstrapVer int    `yaml:"bootstrap_version"`
+	Socks5            string `yaml:"socks5"`
+	SoMark            int    `yaml:"so_mark"`
+	BindToDevice      string `yaml:"bind_to_device"`
+	EnableTCPFastOpen bool   `yaml:"enable_tfo"`
+	Bootstrap         string `yaml:"bootstrap"`
+	BootstrapVer      int    `yaml:"bootstrap_version"`
 }
 
 type UpstreamConfig struct {
@@ -76,11 +77,12 @@ type UpstreamConfig struct {
 	EnableHTTP3        bool `yaml:"enable_http3"`
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 
-	Socks5       string `yaml:"socks5"`
-	SoMark       int    `yaml:"so_mark"`
-	BindToDevice string `yaml:"bind_to_device"`
-	Bootstrap    string `yaml:"bootstrap"`
-	BootstrapVer int    `yaml:"bootstrap_version"`
+	Socks5            string `yaml:"socks5"`
+	SoMark            int    `yaml:"so_mark"`
+	BindToDevice      string `yaml:"bind_to_device"`
+	EnableTCPFastOpen bool   `yaml:"enable_tfo"`
+	Bootstrap         string `yaml:"bootstrap"`
+	BootstrapVer      int    `yaml:"bootstrap_version"`
 }
 
 func Init(bp *coremain.BP, args any) (any, error) {
@@ -131,6 +133,9 @@ func NewForward(args *Args, opt Opts) (*Forward, error) {
 		utils.SetDefaultString(&c.Socks5, args.Socks5)
 		utils.SetDefaultUnsignNum(&c.SoMark, args.SoMark)
 		utils.SetDefaultString(&c.BindToDevice, args.BindToDevice)
+		if args.EnableTCPFastOpen {
+			c.EnableTCPFastOpen = true
+		}
 		utils.SetDefaultString(&c.Bootstrap, args.Bootstrap)
 		utils.SetDefaultUnsignNum(&c.BootstrapVer, args.BootstrapVer)
 	}
@@ -143,15 +148,16 @@ func NewForward(args *Args, opt Opts) (*Forward, error) {
 
 		uw := newWrapper(i, c, opt.MetricsTag)
 		uOpt := upstream.Opt{
-			DialAddr:       c.DialAddr,
-			Socks5:         c.Socks5,
-			SoMark:         c.SoMark,
-			BindToDevice:   c.BindToDevice,
-			IdleTimeout:    time.Duration(c.IdleTimeout) * time.Second,
-			EnablePipeline: c.EnablePipeline,
-			EnableHTTP3:    c.EnableHTTP3,
-			Bootstrap:      c.Bootstrap,
-			BootstrapVer:   c.BootstrapVer,
+			DialAddr:          c.DialAddr,
+			Socks5:            c.Socks5,
+			SoMark:            c.SoMark,
+			BindToDevice:      c.BindToDevice,
+			EnableTCPFastOpen: c.EnableTCPFastOpen,
+			IdleTimeout:       time.Duration(c.IdleTimeout) * time.Second,
+			EnablePipeline:    c.EnablePipeline,
+			EnableHTTP3:       c.EnableHTTP3,
+			Bootstrap:         c.Bootstrap,
+			BootstrapVer:      c.BootstrapVer,
 			TLSConfig: &tls.Config{
 				InsecureSkipVerify: c.InsecureSkipVerify,
 				ClientSessionCache: tls.NewLRUClientSessionCache(4),

--- a/plugin/matcher/qname_geosite/qname_geosite.go
+++ b/plugin/matcher/qname_geosite/qname_geosite.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020-2022, IrineSistiana
+ *
+ * This file is part of mosdns.
+ *
+ * mosdns is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * mosdns is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package qname_geosite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/IrineSistiana/mosdns/v5/pkg/matcher/domain"
+	"github.com/IrineSistiana/mosdns/v5/pkg/query_context"
+	"github.com/IrineSistiana/mosdns/v5/plugin/data_provider"
+	"github.com/IrineSistiana/mosdns/v5/plugin/executable/sequence"
+)
+
+const PluginType = "qname_geosite"
+
+func init() {
+	sequence.MustRegMatchQuickSetup(PluginType, QuickSetup)
+}
+
+func QuickSetup(bq sequence.BQ, s string) (sequence.Matcher, error) {
+	if len(s) == 0 {
+		return nil, errors.New("a geosite plugin and code are required")
+	}
+
+	args := strings.Fields(s)
+	if len(args) != 2 {
+		return nil, errors.New("args error, must like: qname_geosite $plugin_name cn")
+	}
+
+	geositeName, _ := cutPrefix(args[0], "$")
+
+	p := bq.M().GetPlugin(geositeName)
+	provider, _ := p.(data_provider.GeositeMatcherProvider)
+	if provider == nil {
+		return nil, fmt.Errorf("cannot find geosite %s", geositeName)
+	}
+	m, ok := provider.GetGeositeMatcher(args[1])
+	if !ok {
+		return nil, fmt.Errorf("cannot find geosite code %s", args[1])
+	}
+
+	return &Matcher{m: m}, nil
+}
+
+type Matcher struct {
+	m domain.Matcher[struct{}]
+}
+
+func (m *Matcher) Match(_ context.Context, qCtx *query_context.Context) (bool, error) {
+	for _, question := range qCtx.Q().Question {
+		if _, ok := m.m.Match(question.Name); ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func cutPrefix(s string, p string) (string, bool) {
+	if strings.HasPrefix(s, p) {
+		return strings.TrimPrefix(s, p), true
+	}
+	return s, false
+}

--- a/plugin/matcher/resp_ip_geoip/resp_ip_geoip.go
+++ b/plugin/matcher/resp_ip_geoip/resp_ip_geoip.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020-2022, IrineSistiana
+ *
+ * This file is part of mosdns.
+ *
+ * mosdns is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * mosdns is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package resp_ip_geoip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/IrineSistiana/mosdns/v5/pkg/matcher/netlist"
+	"github.com/IrineSistiana/mosdns/v5/pkg/query_context"
+	"github.com/IrineSistiana/mosdns/v5/plugin/data_provider"
+	"github.com/IrineSistiana/mosdns/v5/plugin/executable/sequence"
+	"github.com/miekg/dns"
+)
+
+const PluginType = "resp_ip_geoip"
+
+func init() {
+	sequence.MustRegMatchQuickSetup(PluginType, QuickSetup)
+}
+
+func QuickSetup(bq sequence.BQ, s string) (sequence.Matcher, error) {
+	if len(s) == 0 {
+		return nil, errors.New("a geoip plugin and country code are required")
+	}
+
+	args := strings.Fields(s)
+	if len(args) != 2 {
+		return nil, errors.New("args error, must like: resp_ip_geoip $plugin_name CN")
+	}
+
+	geoIPName, _ := cutPrefix(args[0], "$")
+
+	p := bq.M().GetPlugin(geoIPName)
+	provider, _ := p.(data_provider.GeoIPMatcherProvider)
+	if provider == nil {
+		return nil, fmt.Errorf("cannot find geoip %s", geoIPName)
+	}
+	m, ok := provider.GetGeoIPMatcher(args[1])
+	if !ok {
+		return nil, fmt.Errorf("cannot find geoip code %s", args[1])
+	}
+
+	return &Matcher{m: m}, nil
+}
+
+type Matcher struct {
+	m netlist.Matcher
+}
+
+func (m *Matcher) Match(_ context.Context, qCtx *query_context.Context) (bool, error) {
+	r := qCtx.R()
+	if r == nil {
+		return false, nil
+	}
+
+	for _, rr := range r.Answer {
+		var addr netip.Addr
+		switch rr := rr.(type) {
+		case *dns.A:
+			addr, _ = netip.AddrFromSlice(rr.A)
+		case *dns.AAAA:
+			addr, _ = netip.AddrFromSlice(rr.AAAA)
+		default:
+			continue
+		}
+		if addr.IsValid() && m.m.Match(addr) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func cutPrefix(s string, p string) (string, bool) {
+	if strings.HasPrefix(s, p) {
+		return strings.TrimPrefix(s, p), true
+	}
+	return s, false
+}

--- a/plugin/matcher/resp_ip_mmdb/resp_ip_mmdb.go
+++ b/plugin/matcher/resp_ip_mmdb/resp_ip_mmdb.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020-2022, IrineSistiana
+ *
+ * This file is part of mosdns.
+ *
+ * mosdns is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * mosdns is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package resp_ip_mmdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/IrineSistiana/mosdns/v5/pkg/query_context"
+	"github.com/IrineSistiana/mosdns/v5/plugin/data_provider"
+	"github.com/IrineSistiana/mosdns/v5/plugin/executable/sequence"
+	"github.com/miekg/dns"
+	"github.com/oschwald/geoip2-golang"
+	"net"
+	"strings"
+)
+
+const PluginType = "resp_ip_mmdb"
+
+func init() {
+	sequence.MustRegMatchQuickSetup(PluginType, QuickSetup)
+}
+
+func QuickSetup(bq sequence.BQ, s string) (sequence.Matcher, error) {
+	if len(s) == 0 {
+		return nil, errors.New("a iso code probability is required")
+	}
+
+	args := strings.Fields(s)
+	if len(args) != 2 {
+		return nil, errors.New("probability error, must like: resp_ip_mmdb $plugin_name CN")
+	}
+
+	mmdbName, _ := cutPrefix(args[0], "$")
+
+	p := bq.M().GetPlugin(mmdbName)
+	provider, _ := p.(data_provider.MmdbMatcherProvider)
+	if provider == nil {
+		return nil, fmt.Errorf("cannot find mmdb %s", mmdbName)
+	}
+	m := provider.GetMmdbMatcher()
+
+	return &Matcher{args[1], m}, nil
+}
+
+type Matcher struct {
+	isoCode string
+	mmdb    *geoip2.Reader
+}
+
+func (m *Matcher) Match(_ context.Context, qCtx *query_context.Context) (bool, error) {
+	r := qCtx.R()
+	if r == nil {
+		return false, nil
+	}
+
+	if m.mmdb == nil {
+		return false, nil
+	}
+
+	for _, rr := range r.Answer {
+		var ip net.IP
+		switch rr := rr.(type) {
+		case *dns.A:
+			ip = rr.A
+		case *dns.AAAA:
+			ip = rr.AAAA
+		default:
+			continue
+		}
+
+		record, err := m.mmdb.Country(ip)
+		if err != nil {
+			continue
+		}
+
+		if record.Country.IsoCode == m.isoCode {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func cutPrefix(s string, p string) (string, bool) {
+	if strings.HasPrefix(s, p) {
+		return strings.TrimPrefix(s, p), true
+	}
+	return s, false
+}

--- a/plugin/server/http_server/http_server.go
+++ b/plugin/server/http_server/http_server.go
@@ -46,11 +46,12 @@ type Args struct {
 		Exec string `yaml:"exec"`
 		Path string `yaml:"path"`
 	} `yaml:"entries"`
-	Listen      string `yaml:"listen"`
-	SrcIPHeader string `yaml:"src_ip_header"`
-	Cert        string `yaml:"cert"`
-	Key         string `yaml:"key"`
-	IdleTimeout int    `yaml:"idle_timeout"`
+	Listen            string `yaml:"listen"`
+	SrcIPHeader       string `yaml:"src_ip_header"`
+	Cert              string `yaml:"cert"`
+	Key               string `yaml:"key"`
+	IdleTimeout       int    `yaml:"idle_timeout"`
+	EnableTCPFastOpen bool   `yaml:"enable_tfo"`
 }
 
 func (a *Args) init() {
@@ -87,8 +88,9 @@ func StartServer(bp *coremain.BP, args *Args) (*HttpServer, error) {
 	}
 
 	socketOpt := server_utils.ListenerSocketOpts{
-		SO_REUSEPORT: true,
-		SO_RCVBUF:    64 * 1024,
+		SO_REUSEPORT:  true,
+		SO_RCVBUF:     64 * 1024,
+		TCP_FAST_OPEN: args.EnableTCPFastOpen,
 	}
 	lc := net.ListenConfig{Control: server_utils.ListenerControl(socketOpt)}
 

--- a/plugin/server/server_utils/socket_utils.go
+++ b/plugin/server/server_utils/socket_utils.go
@@ -9,7 +9,8 @@ func NopControlFunc(network, address string, c syscall.RawConn) error {
 }
 
 type ListenerSocketOpts struct {
-	SO_REUSEPORT bool
-	SO_RCVBUF    int
-	SO_SNDBUF    int
+	SO_REUSEPORT  bool
+	SO_RCVBUF     int
+	SO_SNDBUF     int
+	TCP_FAST_OPEN bool
 }

--- a/plugin/server/server_utils/socket_utils_linux.go
+++ b/plugin/server/server_utils/socket_utils_linux.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const tcpFastOpenBacklog = 4096
+
 func ListenerControl(opt ListenerSocketOpts) ControlFunc {
 	return func(network, address string, c syscall.RawConn) error {
 		var (
@@ -16,6 +18,13 @@ func ListenerControl(opt ListenerSocketOpts) ControlFunc {
 		)
 
 		errControl = c.Control(func(fd uintptr) {
+			if opt.TCP_FAST_OPEN && isTCPNetwork(network) {
+				errSyscall = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_FASTOPEN, tcpFastOpenBacklog)
+				if errSyscall != nil {
+					return
+				}
+			}
+
 			if opt.SO_REUSEPORT {
 				errSyscall = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 				if errSyscall != nil {
@@ -42,5 +51,14 @@ func ListenerControl(opt ListenerSocketOpts) ControlFunc {
 			return errControl
 		}
 		return errSyscall
+	}
+}
+
+func isTCPNetwork(network string) bool {
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		return true
+	default:
+		return false
 	}
 }

--- a/plugin/server/tcp_server/tcp_server.go
+++ b/plugin/server/tcp_server/tcp_server.go
@@ -41,11 +41,12 @@ func init() {
 }
 
 type Args struct {
-	Entry       string `yaml:"entry"`
-	Listen      string `yaml:"listen"`
-	Cert        string `yaml:"cert"`
-	Key         string `yaml:"key"`
-	IdleTimeout int    `yaml:"idle_timeout"`
+	Entry             string `yaml:"entry"`
+	Listen            string `yaml:"listen"`
+	Cert              string `yaml:"cert"`
+	Key               string `yaml:"key"`
+	IdleTimeout       int    `yaml:"idle_timeout"`
+	EnableTCPFastOpen bool   `yaml:"enable_tfo"`
 }
 
 func (a *Args) init() {
@@ -83,8 +84,9 @@ func StartServer(bp *coremain.BP, args *Args) (*TcpServer, error) {
 	}
 
 	socketOpt := server_utils.ListenerSocketOpts{
-		SO_REUSEPORT: true,
-		SO_RCVBUF:    64 * 1024,
+		SO_REUSEPORT:  true,
+		SO_RCVBUF:     64 * 1024,
+		TCP_FAST_OPEN: args.EnableTCPFastOpen,
 	}
 	lc := net.ListenConfig{Control: server_utils.ListenerControl(socketOpt)}
 	listenerNetwork := "tcp"


### PR DESCRIPTION
#554 
#547 
# 增加 Maxmind DB 匹配器，用于匹配 response ip

1. 增加一个`data_provider`插件`mmdb`，用于指定mmdb文件
2. 增加一个`matcher`插件`resp_ip_mmdb`，用于匹配 response ip

PS：mmdb一般情况是只有匹配DNS结果IP的需要，所以只增加了response匹配

使用示例如下：

``` yaml
plugins:
  - tag: country
    type: mmdb
    args:
      file: "./rules/Country.mmdb"

  - tag: main_sequence
    type: sequence
    args:
      - exec: $forward_local
      - matches: resp_ip_mmdb $country CN
        exec: query_summary CN mmdb
```