### PR TITLE
[Feature]: Add UDP SO_REUSEADDR Support to make mosdns compatible with UDP TPROXY

### DIFF
--- a/coremain/config.go
+++ b/coremain/config.go
@@ -77,6 +77,16 @@ type ServerListenerConfig struct {
 	ProxyProtocol       bool   `yaml:"proxy_protocol"`          // accepting the PROXYProtocol
 
 	IdleTimeout uint `yaml:"idle_timeout"` // (sec) used by tcp, dot, doh as connection idle timeout.
+
+	// Issue: https://github.com/IrineSistiana/mosdns/pull/657
+	// https://github.com/AdguardTeam/AdGuardHome/issues/1861#issuecomment-1500404059
+	// When a TPROXY is processing a UDP connection,
+	// for example: if the Dest Addr is 8.8.8.8:53,
+	// the TPROXY program must bind to 8.8.8.8:53 on TPROXY host os
+	// and send the UDP packet back to the Client to make sure the Src Addr and Port is 8.8.8.8:53 ,
+	// IF, when mosdns has bind :53 on this host os without SO_REUSEADDR,
+	// the behavior of the TPROXY program will fail with EADDRINUSE (Address already in use)
+	ReuseAddr bool `yaml:"reuse_addr"` // used by udp on unix alike systems.
 }
 
 type APIConfig struct {

--- a/coremain/utilities_other.go
+++ b/coremain/utilities_other.go
@@ -1,0 +1,15 @@
+//go:build !(linux || darwin || freebsd || netbsd || openbsd)
+
+package coremain
+
+import (
+	"errors"
+	"syscall"
+)
+
+func serverSocketOption(c syscall.RawConn, cfg *ServerListenerConfig, network, address string) error {
+	if cfg.ReuseAddr {
+		return errors.New("reuseaddr not supported on this platform")
+	}
+	return nil
+}

--- a/coremain/utilities_unix.go
+++ b/coremain/utilities_unix.go
@@ -1,0 +1,20 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd
+
+package coremain
+
+import (
+	"syscall"
+)
+
+func serverSocketOption(c syscall.RawConn, cfg *ServerListenerConfig, network, address string) error {
+	var errSysCall error
+	errControl := c.Control(func(fd uintptr) {
+		if cfg.ReuseAddr {
+			errSysCall = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+		}
+	})
+	if errSysCall != nil {
+		return errSysCall
+	}
+	return errControl
+}


### PR DESCRIPTION
background scene to  know

https://github.com/AdguardTeam/AdGuardHome/issues/1861#issuecomment-1500404059

https://github.com/Dreamacro/clash/issues/616#issuecomment-611961492

https://github.com/v2ray/v2ray-core/issues/1971


if this PR is merged or accepted, a new PR to `mosdns v5` will be Open soon

this PR will allow  `mosdns v4`  to have the configurable ability   of  `SO_REUSEADDR`  when bind to a UDP port