### PR TITLE
openwrt-init-script: adjusting startup priority

### DIFF
--- a/scripts/openwrt/mosdns-init-openwrt
+++ b/scripts/openwrt/mosdns-init-openwrt
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-START=99
+START=25
 USE_PROCD=1
 
 #####  ONLY CHANGE THIS BLOCK  ######


### PR DESCRIPTION
As a DNS forwarder, mosdns should be started as soon as possible.

Currently in OpenWrt the startup priority for network is 20 and for odhcpd it is 35, so it makes sense to set the startup priority for mosdns to 25.