### PR TITLE
update mapstructure import path for viper 1.20.0+ compatibility

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"github.com/IrineSistiana/mosdns/v5/mlog"
 	"github.com/kardianos/service"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"


### PR DESCRIPTION
Upon upgrading the dependency github.com/spf13/viper to version 1.20.0 or later within the go.mod file, update `mapstructure` import path from `github.com/mitchellh/mapstructure` to `github.com/go-viper/mapstructure/v2` to support Viper 1.20.0+ (see [viper breaking changes](https://github.com/spf13/viper/blob/master/UPGRADE.md#v120x)）
This change fixes compilation errors when using newer viper versions.