### PR TITLE
fix(mlog): use local timezone for log timestamps

### DIFF
--- a/mlog/logger.go
+++ b/mlog/logger.go
@@ -21,10 +21,15 @@ package mlog
 
 import (
 	"fmt"
+	"time"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"os"
 )
+
+// localTimeEncoder uses local timezone via time.Format.
+var localTimeEncoder = zapcore.TimeEncoderOfLayout(time.RFC3339)
 
 type LogConfig struct {
 	// Level, See also zapcore.ParseLevel.
@@ -65,9 +70,13 @@ func NewLogger(lc LogConfig) (*zap.Logger, error) {
 	}
 
 	if lc.Production {
-		return zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), out, lvl)), nil
+		cfg := zap.NewProductionEncoderConfig()
+		cfg.EncodeTime = localTimeEncoder
+		return zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(cfg), out, lvl)), nil
 	}
-	return zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()), out, lvl)), nil
+	cfg := zap.NewDevelopmentEncoderConfig()
+	cfg.EncodeTime = localTimeEncoder
+	return zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(cfg), out, lvl)), nil
 }
 
 // L is a global logger.


### PR DESCRIPTION
## Summary

- Fix log timestamps showing UTC instead of local timezone
- Use `zapcore.TimeEncoderOfLayout(time.RFC3339)` which respects TZ environment variable via `time.Format`

## Problem

MosDNS logs currently show UTC timestamps even when system timezone is set to a different value (e.g., CST for China). This is because Zap's default encoder uses UTC.

## Solution

Use `zapcore.TimeEncoderOfLayout(time.RFC3339)` which internally calls `time.Format`. Since `time.Format` automatically uses local timezone (by reading TZ env var), the log timestamps will match system timezone.

## Test plan

- [x] Build passes
- [x] Deploy and verify log timestamps match system timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)